### PR TITLE
Mejoras al esqueleto

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject funcional-template "0.1.0-SNAPSHOT"
-  :description "Tempalte for functional exercises/tps"
+  :description "Template for functional exercises/tps"
   :url "http://materias.fi.uba.ar/7510/"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/src/exercise8.clj
+++ b/src/exercise8.clj
@@ -7,7 +7,7 @@
 )
 
 (defn fderivative
-  "Returns a function that approximates the derivative of f with error h in the value given to the returned function."
+  "Returns a function that approximates the derivative of f with step h in the value given to the returned function."
   [f h]
   (throw (Exception. "Not implemented."))
 )

--- a/src/exercise8.clj
+++ b/src/exercise8.clj
@@ -1,17 +1,13 @@
 (ns exercise8)
 
-(defn squear 
-  "Returns the squear of a given number"
+(defn square
+  "Returns the square of a given number"
   [x]
   (throw (Exception. "Not implemented."))
 )
 
-(defn fderive
-  "Returns a function that approximates the derive of f with error h in the value given to the returned function."
+(defn fderivative
+  "Returns a function that approximates the derivative of f with error h in the value given to the returned function."
   [f h]
   (throw (Exception. "Not implemented."))
 )
-
-
-
-

--- a/test/exercise8_test.clj
+++ b/test/exercise8_test.clj
@@ -2,18 +2,18 @@
   (:require [clojure.test :refer :all]
             [exercise8 :refer :all]))
 
-; (deftest fderive-sin-zero
-;   (testing "Does approximate the derive of sin."
-;   (is (= ((fderive #(Math/sin %) 0.001) 0) 0.9999998333333416))))
-			    
-; (deftest fderive-sin-five
-;   (testing "Does approximate the derive of sin."
-;   (is (= ((fderive #(Math/sin %) 0.001) 5) 0.2836621381863136))))
-			    
-; (deftest fderive-squear-two
-;   (testing "Does approximate the derive of sin."
-;   (is (= ((fderive squear 0.001) 2) 3.9999999999995595))))
-						    
-; (deftest fderive-squear-6
-;   (testing "Does approximate the derive of sin."
-;   (is (= ((fderive squear 0.001) 6) 12.000000000004007))))
+; (deftest fderivative-sin-zero
+;   (testing "Does approximate the derivative of sin.")
+;   (is (< (- ((fderivative #(Math/sin %) 0.001) 0) 0.9999998333333416) 0.00001)))
+;
+; (deftest fderivative-sin-five
+;   (testing "Does approximate the derivative of sin.")
+;   (is (< (- ((fderivative #(Math/sin %) 0.001) 5) 0.2836621381863136) 0.00001)))
+;
+; (deftest fderivative-square-two
+;   (testing "Does approximate the derivative of sin.")
+;   (is (< (- ((fderivative square 0.001) 2) 3.9999999999995595) 0.00001)))
+;
+; (deftest fderivative-square-6
+;   (testing "Does approximate the derivative of sin.")
+;   (is (< (- ((fderivative square 0.001) 6) 12.000000000004007) 0.00001)))


### PR DESCRIPTION
En el ejercicio 8 había un par de errores de tipeo que hacían difícil entender lo que se pedía. Además en los tests se estaban comparando números con coma flotante por igual, lo que forzaba a probar varias soluciones hasta encontrar la "correcta". 